### PR TITLE
Remove invalid characters from config

### DIFF
--- a/dapr/configuration/eshop-config.yaml
+++ b/dapr/configuration/eshop-config.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   tracing:
     samplingRate: "1"
-+   zipkin:
-+     endpointAddress: "http://zipkin:9411/api/v2/spans"
+    zipkin:
+      endpointAddress: "http://zipkin:9411/api/v2/spans"


### PR DESCRIPTION
There were some invalid '+' characters in the Dapr configuration file which caused Zipkin tracing not to work.
Pretty sneaky, because it looked like part of the editor UI 😉

Fixes #37 and #41 