### PR TITLE
Handle health checks as cross-cutting concern

### DIFF
--- a/src/ApiGateways/Aggregators/Web.Shopping.HttpAggregator/Program.cs
+++ b/src/ApiGateways/Aggregators/Web.Shopping.HttpAggregator/Program.cs
@@ -32,15 +32,7 @@ app.UseAuthorization();
 
 app.MapGet("/", () => Results.LocalRedirect("~/swagger"));
 app.MapControllers();
-app.MapHealthChecks("/hc", new HealthCheckOptions()
-{
-    Predicate = _ => true,
-    ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
-});
-app.MapHealthChecks("/liveness", new HealthCheckOptions
-{
-    Predicate = r => r.Name.Contains("self")
-});
+app.MapCustomHealthChecks("/hc", "/liveness", UIResponseWriter.WriteHealthCheckUIResponse);
 
 try
 {

--- a/src/BuildingBlocks/Healthchecks/GlobalUsings.cs
+++ b/src/BuildingBlocks/Healthchecks/GlobalUsings.cs
@@ -1,4 +1,5 @@
-﻿global using Dapr.Client;
+﻿global using System;
+global using Dapr.Client;
 global using Microsoft.eShopOnDapr.BuildingBlocks.Healthchecks;
 global using Microsoft.Extensions.Diagnostics.HealthChecks;
 global using System.Threading;

--- a/src/BuildingBlocks/Healthchecks/HealthCheckEndpointRouteBuilderExtensions.cs
+++ b/src/BuildingBlocks/Healthchecks/HealthCheckEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class HealthCheckEndpointRouteBuilderExtensions
+{
+    public static void MapCustomHealthChecks(
+        this WebApplication app,
+        string healthPattern = "/hc",
+        string livenessPattern = "/liveness",
+        Func<AspNetCore.Http.HttpContext, HealthReport, Task> responseWriter = default)
+    {
+        app.MapHealthChecks(healthPattern, new HealthCheckOptions()
+        {
+            Predicate = _ => true,
+            ResponseWriter = responseWriter,
+        });
+        app.MapHealthChecks(livenessPattern, new HealthCheckOptions
+        {
+            Predicate = r => r.Name.Contains("self")
+        });
+    }
+}

--- a/src/BuildingBlocks/Healthchecks/Healthchecks.csproj
+++ b/src/BuildingBlocks/Healthchecks/Healthchecks.csproj
@@ -5,7 +5,9 @@
     <RootNamespace>Microsoft.eShopOnDapr.BuildingBlocks.Healthchecks</RootNamespace>
     <AssemblyName>Microsoft.eShopOnDapr.BuildingBlocks.Healthchecks</AssemblyName>
   </PropertyGroup>
-
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dapr.Client" Version="1.6.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.2" />

--- a/src/Services/Basket/Basket.API/Program.cs
+++ b/src/Services/Basket/Basket.API/Program.cs
@@ -32,15 +32,7 @@ app.UseCors("CorsPolicy");
 app.MapDefaultControllerRoute();
 app.MapControllers();
 app.MapSubscribeHandler();
-app.MapHealthChecks("/hc", new HealthCheckOptions()
-{
-    Predicate = _ => true,
-    ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
-});
-app.MapHealthChecks("/liveness", new HealthCheckOptions
-{
-    Predicate = r => r.Name.Contains("self")
-});
+app.MapCustomHealthChecks("/hc", "/liveness", UIResponseWriter.WriteHealthCheckUIResponse);
 
 try
 {

--- a/src/Services/Catalog/Catalog.API/Program.cs
+++ b/src/Services/Catalog/Catalog.API/Program.cs
@@ -36,15 +36,7 @@ app.UseCloudEvents();
 app.MapGet("/", () => Results.LocalRedirect("~/swagger"));
 app.MapControllers();
 app.MapSubscribeHandler();
-app.MapHealthChecks("/hc", new HealthCheckOptions()
-{
-    Predicate = _ => true,
-    ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
-});
-app.MapHealthChecks("/liveness", new HealthCheckOptions
-{
-    Predicate = r => r.Name.Contains("self")
-});
+app.MapCustomHealthChecks("/hc", "/liveness", UIResponseWriter.WriteHealthCheckUIResponse);
 
 try
 {

--- a/src/Services/Ordering/Ordering.API/Program.cs
+++ b/src/Services/Ordering/Ordering.API/Program.cs
@@ -41,15 +41,7 @@ app.MapGet("/", () => Results.LocalRedirect("~/swagger"));
 app.MapControllers();
 app.MapActorsHandlers();
 app.MapSubscribeHandler();
-app.MapHealthChecks("/hc", new HealthCheckOptions()
-{
-    Predicate = _ => true,
-    ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
-});
-app.MapHealthChecks("/liveness", new HealthCheckOptions
-{
-    Predicate = r => r.Name.Contains("self")
-});
+app.MapCustomHealthChecks("/hc", "/liveness", UIResponseWriter.WriteHealthCheckUIResponse);
 app.MapHub<NotificationsHub>("/hub/notificationhub",
     options => options.Transports = Microsoft.AspNetCore.Http.Connections.HttpTransportType.LongPolling);
 

--- a/src/Web/WebStatus/Program.cs
+++ b/src/Web/WebStatus/Program.cs
@@ -16,10 +16,14 @@ if (!string.IsNullOrEmpty(pathBase))
 
 app.UseHealthChecksUI(config =>
 {
-    config.ResourcesPath = string.IsNullOrEmpty(pathBase) ? "/ui/resources" : $"{pathBase}/ui/resources";
+    config.ResourcesPath = string.IsNullOrEmpty(pathBase)
+        ? "/ui/resources"
+        : $"{pathBase}/ui/resources";
 });
 
-app.MapGet(string.IsNullOrEmpty(pathBase) ? "/" : pathBase, () => Results.LocalRedirect("~/healthchecks-ui"));
+app.MapGet(string.IsNullOrEmpty(pathBase)
+    ? "/"
+    : pathBase, () => Results.LocalRedirect("~/healthchecks-ui"));
 app.MapHealthChecksUI();
 
 app.Run();


### PR DESCRIPTION
## Motivation:

I would like to clean up `Program.cs` files a little bit. System-wide well-known health checks are re-usable and could be moved to BuildingBlocks.

My proposal is based on my experience of learning Dapr from the reference application. In my opinion, code is responsible for handling health checks diverts the attention of a reader from high-level details of `Program.cs`. It would be nice to handle cross-cutting concerns in a consistent way. 

I understand that this pull request was created out of blue, please feel free to close it if you want to.