### PR TITLE
Fix startup errors caused by missing secret store

### DIFF
--- a/deploy/containerapps/modules/apps/catalog-api.bicep
+++ b/deploy/containerapps/modules/apps/catalog-api.bicep
@@ -3,12 +3,20 @@ param seqFqdn string
 
 param containerAppsEnvironmentId string
 
+param managedIdentityId string
+
 @secure()
 param catalogDbConnectionString string
 
 resource containerApp 'Microsoft.App/containerApps@2022-03-01' = {
   name: 'catalog-api'
   location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${managedIdentityId}': {}
+    }
+  }
   properties: {
     managedEnvironmentId: containerAppsEnvironmentId
     template: {

--- a/deploy/containerapps/modules/apps/identity-api.bicep
+++ b/deploy/containerapps/modules/apps/identity-api.bicep
@@ -4,12 +4,20 @@ param seqFqdn string
 param containerAppsEnvironmentId string
 param containerAppsEnvironmentDomain string
 
+param managedIdentityId string
+
 @secure()
 param identityDbConnectionString string
 
 resource containerApp 'Microsoft.App/containerApps@2022-03-01' = {
   name: 'identity-api'
   location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${managedIdentityId}': {}
+    }
+  }
   properties: {
     managedEnvironmentId: containerAppsEnvironmentId
     template: {
@@ -60,6 +68,11 @@ resource containerApp 'Microsoft.App/containerApps@2022-03-01' = {
     }
     configuration: {
       activeRevisionsMode: 'single'
+      dapr: {
+        enabled: true
+        appId: 'identity-api'
+        appPort: 80
+      }
       ingress: {
         external: true
         targetPort: 80

--- a/deploy/containerapps/modules/apps/ordering-api.bicep
+++ b/deploy/containerapps/modules/apps/ordering-api.bicep
@@ -4,12 +4,20 @@ param seqFqdn string
 param containerAppsEnvironmentId string
 param containerAppsEnvironmentDomain string
 
+param managedIdentityId string
+
 @secure()
 param orderingDbConnectionString string
 
 resource containerApp 'Microsoft.App/containerApps@2022-03-01' = {
   name: 'ordering-api'
   location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${managedIdentityId}': {}
+    }
+  }
   properties: {
     managedEnvironmentId: containerAppsEnvironmentId
     template: {

--- a/deploy/containerapps/modules/dapr/secretstore.bicep
+++ b/deploy/containerapps/modules/dapr/secretstore.bicep
@@ -1,0 +1,42 @@
+param containerAppsEnvironmentName string
+param vaultName string
+param managedIdentityClientId string
+
+resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2022-03-01' existing = {
+  name: containerAppsEnvironmentName
+
+  resource daprComponent 'daprComponents@2022-03-01' = {
+    name: 'eshopondapr-secretstore'
+    properties: {
+      componentType: 'secretstores.azure.keyvault'
+      version: 'v1'
+      secrets: [
+        {
+          name: 'azure-client-id'
+          value: managedIdentityClientId
+        }
+      ]
+      metadata: [
+        {
+          name: 'vaultName'
+          value: vaultName
+        }
+        {
+          name: 'azureEnvironment'
+          value: 'AZUREPUBLICCLOUD'
+        }
+        {
+          name: 'azureClientId'
+          secretRef: 'azure-client-id'
+        }
+      ]
+      scopes: [
+        'catalog-api'
+        'ordering-api'
+        'identity-api'
+      ]
+    }
+  }
+}
+
+output daprSecretStoreName string = containerAppsEnvironment::daprComponent.name

--- a/deploy/containerapps/modules/infra/container-apps-env.bicep
+++ b/deploy/containerapps/modules/infra/container-apps-env.bicep
@@ -2,6 +2,7 @@ param location string
 param uniqueSeed string
 param containerAppsEnvironmentName string = 'containerappenv-${uniqueString(uniqueSeed)}'
 param logAnalyticsWorkspaceName string = 'loganalytics-${uniqueString(uniqueSeed)}'
+param appInsightsName string = 'appinsights-${uniqueString(uniqueSeed)}'
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-03-01-preview' = {
   name: logAnalyticsWorkspaceName
@@ -17,10 +18,20 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-03
   })
 }
 
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: appInsightsName
+  location: location
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+  }
+}
+
 resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2022-03-01' = {
   name: containerAppsEnvironmentName
   location: location
   properties: {
+    daprAIInstrumentationKey: appInsights.properties.InstrumentationKey
     appLogsConfiguration: {
       destination: 'log-analytics'
       logAnalyticsConfiguration: {

--- a/deploy/containerapps/modules/infra/identity.bicep
+++ b/deploy/containerapps/modules/infra/identity.bicep
@@ -1,0 +1,13 @@
+param uniqueSeed string
+param location string
+param identityName string = 'id-${uniqueString(uniqueSeed)}'
+
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2022-01-31-preview' = {
+  name: identityName
+  location: location
+}
+
+output identityId string = managedIdentity.id
+output identityClientId string = managedIdentity.properties.clientId
+output identityObjectId string = managedIdentity.properties.principalId
+

--- a/deploy/containerapps/modules/infra/keyvault.bicep
+++ b/deploy/containerapps/modules/infra/keyvault.bicep
@@ -1,0 +1,61 @@
+param uniqueSeed string
+param location string
+param vaultName string = 'kv-${uniqueString(uniqueSeed)}'
+param managedIdentityObjectId string
+param catalogDbConnectionString string
+param orderingDbConnectionString string
+param identityDbConnectionString string
+
+resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
+  name: vaultName
+  location: location
+  properties: {
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    tenantId: subscription().tenantId
+    accessPolicies: [
+      {
+        tenantId: subscription().tenantId
+        objectId: managedIdentityObjectId
+        permissions: {
+          secrets: [
+            'get'
+            'list'
+            'set'
+            'delete'
+          ]
+        }
+      }
+    ]
+    enabledForDeployment: false
+    enabledForDiskEncryption: false
+    enabledForTemplateDeployment: false
+    enableSoftDelete: false
+  }
+}
+
+resource catalogDbConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVault.name}/catalogDbConnectionString'
+  properties: {
+    value: catalogDbConnectionString
+  }
+}
+
+resource orderDbConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVault.name}/orderDbConnectionString'
+  properties: {
+    value: orderingDbConnectionString
+  }
+}
+
+resource identityDbConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVault.name}/identityDbConnectionString'
+  properties: {
+    value: identityDbConnectionString
+  }
+}
+
+output vaultName string = keyVault.name
+


### PR DESCRIPTION
As noted in #120 the container apps based deployment was not working because it's missing the `eshopondapr-secretstore ` Dapr component. In this PR, I've fixed that as follows

- Added a bicep file to create a managed identity for Dapr to use to access Key Vault
- Added a bicep file to create a Key Vault along with the secrets for the SQL database connection strings and an access policy to allow the managed identity to retrieve those secrets
- The `identity-api` did not have Dapr enabled, so I've updated the bicep file to do that.
- The `identity-api`, `ordering-api` and `catalog-api` bicep files have been updated to add the managed identity that Dapr will use to access Key Vault.
- Added a bicep file to create the `eshopondapr-secretstore` Dapr component and scope it for use by the `identity-api`, `ordering-api` and `catalog-api`.

I've also enhanced the deployment by adding Application Insights and modifying the Container App Environment bicep file to link to the App Insights instance.  So, you'll now get Application Maps and all the other cool stuff that Dapr and App Insights provide.