### PR TITLE
Changed service from redis to rabbitmq

### DIFF
--- a/deploy/k8s/helm/templates/rabbitmq.yaml
+++ b/deploy/k8s/helm/templates/rabbitmq.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     app: eshop
-    service: redis
+    service: rabbitmq
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Imho opinion, the service in the rabbitmq deployment needs to be rabbitmq instead of redis.